### PR TITLE
build: fix package root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,19 @@
 pack:
 	@echo "Packaging..." \
-	&& wasm-pack build --target web --out-dir dist/pkg --release \
+	&& wasm-pack build --target web --out-dir dist/pkg --debug \
 	&& cp -f README.md dist/README.md \
 	&& cp -f LICENSE dist/LICENSE \
 	&& rm -f dist/pkg/LICENSE \
 	&& rm -f dist/pkg/README.md \
 	&& cd dist \
 	&& npm pack
+
+publish:
+	@echo "Publishing..." \
+	&& wasm-pack build --target web --out-dir dist/pkg --release \
+	&& cp -f README.md dist/README.md \
+	&& cp -f LICENSE dist/LICENSE \
+	&& rm -f dist/pkg/LICENSE \
+	&& rm -f dist/pkg/README.md \
+	&& cd dist \
+	&& npm puplish

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+pack:
+	@echo "Packaging..." \
+	&& wasm-pack build --target web --out-dir dist/pkg --release \
+	&& cp -f README.md dist/README.md \
+	&& cp -f LICENSE dist/LICENSE \
+	&& rm -f dist/pkg/LICENSE \
+	&& rm -f dist/pkg/README.md \
+	&& cd dist \
+	&& npm pack

--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -1,0 +1,3 @@
+*.tgz
+README.md
+LICENSE

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,4 @@
-import init from "./pkg/lydie";
+import init, { ColorModel } from "./pkg/lydie";
 
 export default init;
 
@@ -7,9 +7,9 @@ export * from "./pkg/lydie";
 export class Lydie {
   public image: Image;
   constructor(
-    arr: number[],
+    imageArray: Uint32Array,
     width: number,
     height: number,
-    wasmMemory: WebAssembly.Memory
+    ColorModel: ColorModel
   );
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,15 @@
+import init from "./pkg/lydie";
+
+export default init;
+
+export * from "./pkg/lydie";
+
+export class Lydie {
+  public image: Image;
+  constructor(
+    arr: number[],
+    width: number,
+    height: number,
+    wasmMemory: WebAssembly.Memory
+  );
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,16 +1,10 @@
-import init, { Image, ColorModel } from "./pkg/lydie.js";
+import init, { Image } from "./pkg/lydie.js";
 export default init;
 
 export * from "./pkg/lydie.js";
 
 export class Lydie {
-  constructor(imageArray, width, height, wasmMemory) {
-    this.image = new Image(imageArray.length, width, height, ColorModel.RGB);
-    const ar = new Uint32Array(
-      wasmMemory.buffer,
-      this.image.hsv_pointer,
-      imageArray.length
-    );
-    ar.set(imageArray);
+  constructor(imageArray, width, height, ColorModel) {
+    this.image = new Image(imageArray, width, height, ColorModel);
   }
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,16 @@
+import init, { Image, ColorModel } from "./pkg/lydie.js";
+export default init;
+
+export * from "./pkg/lydie.js";
+
+export class Lydie {
+  constructor(imageArray, width, height, wasmMemory) {
+    this.image = new Image(imageArray.length, width, height, ColorModel.RGB);
+    const ar = new Uint32Array(
+      wasmMemory.buffer,
+      this.image.hsv_pointer,
+      imageArray.length
+    );
+    ar.set(imageArray);
+  }
+}

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "lydie",
+  "collaborators": [
+    "seyyyy"
+  ],
+  "description": "sampling color",
+  "version": "0.1.2",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Seyyyy/lydie.git"
+  },
+  "files": [
+    "pkg/lydie_bg.wasm",
+    "pkg/lydie.js",
+    "pkg/lydie.d.ts",
+    "index.js",
+    "index.d.ts"
+  ],
+  "module": "index.js",
+  "homepage": "https://github.com/Seyyyy/lydie#readme",
+  "types": "index.d.ts",
+  "sideEffects": [
+    "./snippets/*"
+  ]
+}


### PR DESCRIPTION
Fix npm package root.
Because the package output by wasm is to be modified by javascript.
This change can add flexibility to the package interface.