### PR TITLE
perf: fix heap allocation with Vec::with_capacity

### DIFF
--- a/src/formatter/array.rs
+++ b/src/formatter/array.rs
@@ -1,23 +1,23 @@
 pub fn convert_2d_array(arr: &Vec<u16>, width: usize, height: usize) -> Vec<Vec<u16>> {
-    let mut result = vec![vec![0; 3]; width * height];
+    let mut result = Vec::with_capacity(width * height);
     for i in 0..height {
         for j in 0..width {
             let index = i * width + j;
             let h = arr[index * 3];
             let s = arr[index * 3 + 1];
             let v = arr[index * 3 + 2];
-            result[index] = vec![h, s, v];
+            result.push(vec![h, s, v]);
         }
     }
     result
 }
 
 pub fn convert_flat_2d_array(arr: &Vec<Vec<u16>>) -> Vec<u16> {
-    let mut result = vec![0; arr.len() * 3];
+    let mut result = Vec::with_capacity(arr.len() * 3);
     for i in 0..arr.len() {
-        result[i * 3] = arr[i][0];
-        result[i * 3 + 1] = arr[i][1];
-        result[i * 3 + 2] = arr[i][2];
+        result.push(arr[i][0]);
+        result.push(arr[i][1]);
+        result.push(arr[i][2]);
     }
     result
 }


### PR DESCRIPTION
Performance improvement by fix heap allocation with Vec::with_capacity.
If Vec::with_capacity is used, only one allocation is needed. But if not used, allocation occurs for the number of array elements.