### PR TITLE
perf: use pointer for instantiate

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,4 @@
-import init, { ColorModel } from "./pkg/lydie";
+import init from "./pkg/lydie";
 
 export default init;
 
@@ -7,9 +7,9 @@ export * from "./pkg/lydie";
 export class Lydie {
   public image: Image;
   constructor(
-    imageArray: Uint32Array,
+    imageArray: number[],
     width: number,
     height: number,
-    ColorModel: ColorModel
+    wasmMemory: WebAssembly.Memory
   );
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -4,7 +4,19 @@ export default init;
 export * from "./pkg/lydie.js";
 
 export class Lydie {
-  constructor(imageArray, width, height, ColorModel) {
-    this.image = new Image(imageArray, width, height, ColorModel);
+  /**
+   * @param {number[]} inputArray
+   * @param {number} width
+   * @param {number} height
+   * @param {WebAssembly.Memory} wasmMemory
+   */
+  constructor(inputArray, width, height, wasmMemory) {
+    this.image = new Image(inputArray.length, width, height);
+    const imageArray = new Uint16Array(
+      wasmMemory.buffer,
+      this.image.hsv_pointer,
+      inputArray.length
+    );
+    imageArray.set(inputArray);
   }
 }


### PR DESCRIPTION
Performance improvement by use pointer when instantiate.
Change the instantiate method used clone TypedArray to used Webassembly.Memory.buffer.