### PR TITLE
ci: fix assignee

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "friday"
     target-branch: main
     labels: ["dependencies"]
+    assignees:
+      - "Seyyyy"
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -14,3 +16,5 @@ updates:
       day: "friday"
     target-branch: main
     labels: ["dependencies"]
+    assignees:
+      - "Seyyyy"


### PR DESCRIPTION
This pull request fixes the assignee in the dependabot configuration file. Previously, the assignee was set to "Seyyyy", but it should be updated to the correct assignee.